### PR TITLE
Prevent set likes fot invalid id

### DIFF
--- a/src/modules/food-list.js
+++ b/src/modules/food-list.js
@@ -11,7 +11,9 @@ export default class FoodList {
   }
 
   setLikes(id, likes) {
-    this.foods[id].likes = likes;
+    if (Object.keys(this.foods).includes(id)) {
+      this.foods[id].likes = likes;
+    }
   }
 
   getLikes(id) {


### PR DESCRIPTION
This commit prevents adding likes for items with invalid id on involvement API.